### PR TITLE
schemas.py: leave_type_name is optional

### DIFF
--- a/drifactorial/schemas.py
+++ b/drifactorial/schemas.py
@@ -21,7 +21,7 @@ class Leave(BaseModel):
     half_day: Optional[str]
     leave_type_id: int
     employee_full_name: str
-    leave_type_name: str
+    leave_type_name: Optional[str]
 
 
 class Holiday(BaseModel):


### PR DESCRIPTION
`leave_type_name` has to be Optional in the schema **Leave**, so that `pydantic.parse_obj_as` can process None values, thus `get_leaves` works properly